### PR TITLE
Use the data info from dataWrapper instead call the adapter again.

### DIFF
--- a/VirtualListView/Platforms/Windows/IrDataTemplateSelector.cs
+++ b/VirtualListView/Platforms/Windows/IrDataTemplateSelector.cs
@@ -53,8 +53,7 @@ namespace Microsoft.Maui.Controls
 				if (info == null)
 					return null;
 
-				var data = PositionalViewSelector.Adapter.DataFor(info.Kind, info.SectionIndex, info.ItemIndex);
-				var reuseId = PositionalViewSelector?.ViewSelector?.GetReuseId(info, data);
+                var reuseId = PositionalViewSelector?.ViewSelector?.GetReuseId(info, dataWrapper.data);
 
 				RecycledDataTemplate container;
 


### PR DESCRIPTION
Using the control I noticed that  the IrSource and IrDataTemplateSelector called the adapter to get data. That was a duplicated and, in my tests, desnecessary adapter call. I made a small update on the code, I hope that is ok.