### PR TITLE
Bump to MAUI net8.0 RC2, support net8.0 as a TFM

### DIFF
--- a/Sample/VirtualListViewSample/VirtualListViewSample.csproj
+++ b/Sample/VirtualListViewSample/VirtualListViewSample.csproj
@@ -25,7 +25,7 @@
 
 
 	<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">
-		<PackageReference Include="Microsoft.WindowsAppSdk" Version="1.3.230602002" />
+		<PackageReference Include="Microsoft.WindowsAppSdk" Version="1.3.230724000" />
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />

--- a/VirtualListView/HostBuilderExtensions.cs
+++ b/VirtualListView/HostBuilderExtensions.cs
@@ -1,8 +1,10 @@
 ﻿namespace Microsoft.Maui;
 
+#if ANDROID || MACCATALYST || IOS || WINDOWS
 public static class VirtualListViewHostBuilderExtensions
 {
 	public static MauiAppBuilder UseVirtualListView(this MauiAppBuilder builder)
 		=> builder.ConfigureMauiHandlers(handlers =>
 			handlers.AddHandler(typeof(IVirtualListView), typeof(VirtualListViewHandler)));
 }
+#endif

--- a/VirtualListView/VirtualListView.csproj
+++ b/VirtualListView/VirtualListView.csproj
@@ -1,10 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks>net8.0;net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
 		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041</TargetFrameworks>
-		
-		<UseMaui>true</UseMaui>
-		<SingleProject>true</SingleProject>
+
 		<ImplicitUsings>enable</ImplicitUsings>
 
 		<AssemblyName>VirtualListView</AssemblyName>
@@ -25,16 +23,15 @@
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<DebugType>portable</DebugType>
 		<DebugSymbols>true</DebugSymbols>
+		<MauiVersion>8.0.0-rc.2.9373</MauiVersion>
 
-		
 	</PropertyGroup>
 
 	<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">
-		<PackageReference Include="Microsoft.WindowsAppSdk" Version="1.3.230602002" />
-
-		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
+		<PackageReference Include="Microsoft.WindowsAppSdk" Version="1.3.230724000" />
 	</ItemGroup>
 	<ItemGroup>
+		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 		<PackageReference Include="GitInfo" Version="3.1.1" PrivateAssets="all" />
 	</ItemGroup>
 
@@ -73,14 +70,67 @@
 	</ItemGroup>
 
 
-	<Target Name="_MauiRemovePlatformFileNamePatternCompileItems" BeforeTargets="_MauiRemovePlatformCompileItems">
-		<ItemGroup>
-			<Compile Condition=" '%(Compile.ExcludeFromCurrentConfiguration)' == 'true' " Remove="**\*.ios*$(DefaultLanguageSourceExtension)" />
-			<Compile Condition=" '%(Compile.ExcludeFromCurrentConfiguration)' == 'true' " Remove="**\*.maccatalyst*$(DefaultLanguageSourceExtension)" />
-			<Compile Condition=" '%(Compile.ExcludeFromCurrentConfiguration)' == 'true' " Remove="**\*.android*$(DefaultLanguageSourceExtension)" />
-			<Compile Condition=" '%(Compile.ExcludeFromCurrentConfiguration)' == 'true' " Remove="**\*.windows*$(DefaultLanguageSourceExtension)" />
-			<Compile Condition=" '%(Compile.ExcludeFromCurrentConfiguration)' == 'true' " Remove="**\*.tizen*$(DefaultLanguageSourceExtension)" />
-		</ItemGroup>
-	</Target>
+	<ItemGroup Condition="$(TargetFramework.Contains('-ios')) != true AND $(TargetFramework.Contains('-maccatalyst')) != true AND $(TargetFramework.Contains('-tvos')) != true ">
+		<Compile Remove="**\**\*.iOS.cs" />
+		<None Include="**\**\*.iOS.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+		<Compile Remove="**\iOS\**\*.cs" />
+		<None Include="**\iOS\**\*.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+	</ItemGroup>
+	<ItemGroup Condition="$(TargetFramework.Contains('-macos')) != true AND $(TargetFramework.Contains('-ios')) != true AND $(TargetFramework.Contains('-maccatalyst')) != true ">
+		<Compile Remove="**\*.Apple.cs" />
+		<None Include="**\*.Apple.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+		<Compile Remove="**\Apple\**\*.cs" />
+		<None Include="**\Apple\**\*.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+	</ItemGroup>
+	<ItemGroup Condition="$(TargetFramework.Contains('-macos')) != true AND $(TargetFramework.Contains('-tvos')) != true AND $(TargetFramework.Contains('-ios')) != true AND $(TargetFramework.Contains('-maccatalyst')) != true ">
+		<Compile Remove="**\*.AllApple.cs" />
+		<None Include="**\*.AllApple.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+		<Compile Remove="**\AllApple\**\*.cs" />
+		<None Include="**\AllApple\**\*.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+	</ItemGroup>
+	<ItemGroup Condition="$(TargetFramework.Contains('-macos')) != true ">
+		<Compile Remove="**\*.Mac.cs" />
+		<None Include="**\*.Mac.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+		<Compile Remove="**\Mac\**\*.cs" />
+		<None Include="**\Mac\**\*.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+	</ItemGroup>
+	<ItemGroup Condition="$(TargetFramework.Contains('-maccatalyst')) != true">
+		<Compile Remove="**\*.Catalyst.cs" />
+		<None Include="**\*.Catalyst.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+		<Compile Remove="**\Catalyst\**\*.cs" />
+		<None Include="**\Catalyst\**\*.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+	</ItemGroup>
+	<ItemGroup Condition="$(TargetFramework.Contains('-ios')) != true AND $(TargetFramework.Contains('-maccatalyst')) != true">
+		<Compile Remove="**\*.MaciOS.cs" />
+		<None Include="**\*.MaciOS.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+		<Compile Remove="**\MaciOS\**\*.cs" />
+		<None Include="**\MaciOS\**\*.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+	</ItemGroup>
+	<ItemGroup Condition="$(TargetFramework.Contains('-android')) != true ">
+		<Compile Remove="**\**\*.Android.cs" />
+		<None Include="**\**\*.Android.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+		<Compile Remove="**\Android\**\*.cs" />
+		<None Include="**\Android\**\*.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+	</ItemGroup>
+	<ItemGroup Condition="$(TargetFramework.Contains('-windows')) != true ">
+		<Compile Remove="**\*.Windows.cs" />
+		<None Include="**\*.Windows.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+		<Compile Remove="**\Windows\**\*.cs" />
+		<None Include="**\Windows\**\*.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+		<Compile Remove="**\*.uwp.cs" />
+		<None Include="**\*.uwp.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+		<MauiXaml Remove="**\*.Windows.xaml" />
+		<None Include="**\*.Windows.xaml" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+		<Compile Remove="**\*.Windows.xaml.cs" />
+		<None Include="**\*.Windows.xaml.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+		<MauiXaml Remove="**\Windows\**\*.xaml" />
+		<None Include="**\Windows\**\*.xaml" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+		<Compile Remove="**\Windows\**\*.xaml.cs" />
+		<None Include="**\Windows\**\*.xaml.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+	</ItemGroup>
+	<ItemGroup>
+		<Compile Remove="bin\**;obj\**" />
+		<None Remove="bin\**;obj\**" />
+	</ItemGroup>
 
 </Project>

--- a/VirtualListView/VirtualListViewHandler.cs
+++ b/VirtualListView/VirtualListViewHandler.cs
@@ -2,6 +2,7 @@ using Microsoft.Maui.Adapters;
 
 namespace Microsoft.Maui;
 
+#if ANDROID || IOS || MACCATALYST || WINDOWS
 public partial class VirtualListViewHandler
 {
 	public static new IPropertyMapper<IVirtualListView, VirtualListViewHandler> ViewMapper = new PropertyMapper<IVirtualListView, VirtualListViewHandler>(Handlers.ViewHandler.ViewMapper)
@@ -117,3 +118,4 @@ public partial class VirtualListViewHandler
 	}
 
 }
+#endif


### PR DESCRIPTION
- Bumps the base library to MAUI net8.0 RC2
- Removes "UseMaui" and "SingleProject" and adds the multitarget settings directly to the project, as I believe those are the only values being used. This should reduce the amount of external toolings that are loaded. 
- Adds net8.0 as a target. This will allow for using the library in class libraries that are not tied directly to MAUI platform projects and will make it much easier to use this with MAUI Embedding.