### PR TITLE
Perf Improvements & Consistency

### DIFF
--- a/VirtualListView/Apple/CvCell.ios.maccatalyst.cs
+++ b/VirtualListView/Apple/CvCell.ios.maccatalyst.cs
@@ -92,7 +92,10 @@ internal class CvCell : UICollectionViewCell
 	}
 
 	public bool NeedsView
-		=> NativeView == null || !NativeView.TryGetTarget(out var _);
+		=> NativeView == null 
+			|| VirtualView is null
+			|| !NativeView.TryGetTarget(out var _) 
+			|| !VirtualView.TryGetTarget(out var _);
 
 	public WeakReference<IView> VirtualView { get; set; }
 
@@ -113,19 +116,20 @@ internal class CvCell : UICollectionViewCell
 	public void SetupView(IView view)
 	{
         // Create a new platform native view if we don't have one yet
-        if (!(NativeView?.TryGetTarget(out var nativeView) ?? false))
+        if (!(NativeView?.TryGetTarget(out var _) ?? false))
         {
-            nativeView = view.ToPlatform(this.Handler.MauiContext);
+			var nativeView = view.ToPlatform(this.Handler.MauiContext);
             nativeView.Frame = this.ContentView.Frame;
             nativeView.AutoresizingMask = UIViewAutoresizing.FlexibleHeight | UIViewAutoresizing.FlexibleWidth;
-            this.ContentView.AddSubview(nativeView);
-            NativeView = new WeakReference<UIView>(nativeView);
+            
+			this.ContentView.AddSubview(nativeView);
+            
+			NativeView = new WeakReference<UIView>(nativeView);
         }
 
         if (!(VirtualView?.TryGetTarget(out var virtualView) ?? false) || (virtualView?.Handler is null))
         {
-            virtualView = view;
-            VirtualView = new WeakReference<IView>(virtualView);
+            VirtualView = new WeakReference<IView>(view);
         }
     }
 

--- a/VirtualListView/Apple/CvDataSource.ios.maccatalyst.cs
+++ b/VirtualListView/Apple/CvDataSource.ios.maccatalyst.cs
@@ -58,16 +58,13 @@ internal class CvDataSource : UICollectionViewDataSource
 		if (cell.NeedsView)
 		{
 			var view = Handler?.PositionalViewSelector?.ViewSelector?.CreateView(info, data);
-			cell.SwapView(view);
+			cell.SetupView(view);
 		}
 
-		cell.PositionInfo = info;
+		cell.UpdatePosition(info);
 
 		if (cell.VirtualView.TryGetTarget(out var cellVirtualView))
 		{
-			if (cellVirtualView is IPositionInfo viewPositionInfo)
-				viewPositionInfo.IsSelected = info.IsSelected;
-
 			Handler?.PositionalViewSelector?.ViewSelector?.RecycleView(info, data, cellVirtualView);
 
 			Handler.VirtualView.ViewSelector.ViewAttached(info, cellVirtualView);

--- a/VirtualListView/Platforms/Android/RvAdapter.cs
+++ b/VirtualListView/Platforms/Android/RvAdapter.cs
@@ -75,11 +75,15 @@ internal partial class RvAdapter : RecyclerView.Adapter
 				_ => null
 			};
 
-			var view = itemHolder?.VirtualView ?? positionalViewSelector?.ViewSelector?.CreateView(info, data);
+			if (itemHolder?.VirtualView is null)
+			{
+				var newView = positionalViewSelector?.ViewSelector?.CreateView(info, data);
+				itemHolder.SetupView(newView);
+            }
 
-			itemHolder.Update(info, view);
+            itemHolder.UpdatePosition(info);
 
-			positionalViewSelector?.ViewSelector?.RecycleView(info, data, itemHolder.ViewContainer.VirtualView);
+            positionalViewSelector?.ViewSelector?.RecycleView(info, data, itemHolder.ViewContainer.VirtualView);
 		}
 	}
 

--- a/VirtualListView/Platforms/Android/RvAdapter.cs
+++ b/VirtualListView/Platforms/Android/RvAdapter.cs
@@ -75,7 +75,7 @@ internal partial class RvAdapter : RecyclerView.Adapter
 				_ => null
 			};
 
-			if (itemHolder?.VirtualView is null)
+			if (itemHolder.NeedsView)
 			{
 				var newView = positionalViewSelector?.ViewSelector?.CreateView(info, data);
 				itemHolder.SetupView(newView);

--- a/VirtualListView/Platforms/Android/RvItemHolder.cs
+++ b/VirtualListView/Platforms/Android/RvItemHolder.cs
@@ -23,6 +23,8 @@ internal class RvItemHolder : RecyclerView.ViewHolder
 	public IView VirtualView
 		=> ViewContainer?.VirtualView;
 
+	public bool NeedsView
+        => ViewContainer?.NeedsView ?? true;
 
 	public void SetupView(IView view)
 	{

--- a/VirtualListView/Platforms/Android/RvItemHolder.cs
+++ b/VirtualListView/Platforms/Android/RvItemHolder.cs
@@ -1,5 +1,6 @@
 ﻿using Android.Views;
 using AndroidX.RecyclerView.Widget;
+using Microsoft.Maui.Controls;
 
 namespace Microsoft.Maui;
 
@@ -22,18 +23,25 @@ internal class RvItemHolder : RecyclerView.ViewHolder
 	public IView VirtualView
 		=> ViewContainer?.VirtualView;
 
-	public void Update(PositionInfo positionInfo, IView newView)
+
+	public void SetupView(IView view)
+	{
+		ViewContainer.SetupView(view);
+	}
+
+	public void UpdatePosition(PositionInfo positionInfo)
 	{
 		PositionInfo = positionInfo;
-
-		if (newView is IPositionInfo viewWithPositionInfo)
-			viewWithPositionInfo.Update(PositionInfo);
-
-		SwapView(newView);
+		ViewContainer.UpdatePosition(positionInfo);
 	}
 
-	void SwapView(IView view)
-	{
-		ViewContainer.SwapView(view);
-	}
+	//public void Update(PositionInfo positionInfo, IView newView)
+	//{
+	//	PositionInfo = positionInfo;
+
+	//	if (newView is IPositionInfo viewWithPositionInfo)
+	//		viewWithPositionInfo.Update(PositionInfo);
+
+ //       ViewContainer.SwapView(newView);
+ //   }
 }

--- a/VirtualListView/Platforms/Android/RvViewContainer.cs
+++ b/VirtualListView/Platforms/Android/RvViewContainer.cs
@@ -18,20 +18,21 @@ sealed class RvViewContainer : Android.Widget.FrameLayout
 
 	public AView NativeView { get; private set; }
 
-	public void SwapView(IView newView)
+	public void UpdatePosition(IPositionInfo positionInfo)
 	{
-		if (VirtualView == null || VirtualView.Handler == null || NativeView == null)
+        if (VirtualView is IPositionInfo viewWithPositionInfo)
+			viewWithPositionInfo.Update(positionInfo);
+    }
+
+    public void SetupView(IView view)
+	{
+		if (NativeView is null)
+			NativeView = view.ToPlatform(MauiContext);
+
+		if (VirtualView is null)
 		{
-			NativeView = newView.ToPlatform(MauiContext);
-			VirtualView = newView;
+			VirtualView = view;
 			AddView(NativeView);
 		}
-		else
-		{
-			var handler = VirtualView.Handler;
-			newView.Handler = handler;
-			handler.SetVirtualView(newView);
-			VirtualView = newView;
-		}
-	}
+    }
 }

--- a/VirtualListView/Platforms/Android/RvViewContainer.cs
+++ b/VirtualListView/Platforms/Android/RvViewContainer.cs
@@ -18,6 +18,8 @@ sealed class RvViewContainer : Android.Widget.FrameLayout
 
 	public AView NativeView { get; private set; }
 
+	public bool NeedsView => VirtualView is null || VirtualView.Handler is null || NativeView is null;
+
 	public void UpdatePosition(IPositionInfo positionInfo)
 	{
         if (VirtualView is IPositionInfo viewWithPositionInfo)

--- a/VirtualListView/Platforms/Windows/IrElementContainer.cs
+++ b/VirtualListView/Platforms/Windows/IrElementContainer.cs
@@ -48,33 +48,27 @@ internal class IrElementContainer : ContentControl
 		}
 	}
 
+	public bool NeedsView
+		=> VirtualView is null || VirtualView.Handler is null;
+
 	public IView VirtualView { get; private set; }
 
-	public void Update(PositionInfo positionInfo, IView newView)
+	public void SetupView(IView view)
 	{
-		PositionInfo = positionInfo;
-
-		if (newView is IPositionInfo viewWithPositionInfo)
-			viewWithPositionInfo.Update(PositionInfo);
-
-		SwapView(newView);
+		if (VirtualView is null || VirtualView.Handler is null)
+		{
+            Content = view.ToPlatform(MauiContext);
+            VirtualView = view;
+        }
 	}
 
-	void SwapView(IView newView)
+	public void UpdatePosition(PositionInfo positionInfo)
 	{
-		if (VirtualView == null || VirtualView.Handler == null || Content == null)
-		{
-			Content = newView.ToPlatform(MauiContext);
-			VirtualView = newView;
-		}
-		else
-		{
-			var handler = VirtualView.Handler;
-			newView.Handler = handler;
-			handler.SetVirtualView(newView);
-			VirtualView = newView;
-		}
-	}
+        PositionInfo = positionInfo;
+
+        if (VirtualView is IPositionInfo viewWithPositionInfo)
+            viewWithPositionInfo.Update(PositionInfo);
+    }
 
 	protected override void OnTapped(TappedRoutedEventArgs e)
 	{

--- a/VirtualListView/Platforms/Windows/IrElementFactory.cs
+++ b/VirtualListView/Platforms/Windows/IrElementFactory.cs
@@ -85,16 +85,17 @@ internal class IrElementFactory : IElementFactory, IDisposable
 				&& (Handler?.IsItemSelected(info.SectionIndex, info.ItemIndex) ?? false);
 
 
-			var view = container.VirtualView ?? PositionalViewSelector.ViewSelector?.CreateView(info, data);
+			if (container.NeedsView)
+			{
+				var virtualView = PositionalViewSelector.ViewSelector?.CreateView(info, data);
+				container.SetupView(virtualView);
+			}
 
-			container.Update(info, view);
-
-
-
+			container.UpdatePosition(info);
 			container.IsRecycled = false;
-			PositionalViewSelector.ViewSelector?.RecycleView(info, data, view);
 
-			PositionalViewSelector.ViewSelector?.ViewAttached(info, view);
+			PositionalViewSelector.ViewSelector?.RecycleView(info, data, container.VirtualView);
+			PositionalViewSelector.ViewSelector?.ViewAttached(info, container.VirtualView);
 
 			return container;
 		}


### PR DESCRIPTION
There were some hot spots determined by profiling around swapping views on android.  This logic was kind of odd to begin with and I don't believe it really was doing anything.  The idea originally was to support Comet hot reloading with it, however given how it was implemented, it really should still have been a no-op.

This speeds things up a bit on android with fixes, and adds some consistency to iOS/Windows in how the view holders are setup.