### PR TITLE
Fix iOS/MacCat cell tap for selection

### DIFF
--- a/VirtualListView/Apple/CvCell.ios.maccatalyst.cs
+++ b/VirtualListView/Apple/CvCell.ios.maccatalyst.cs
@@ -23,7 +23,12 @@ internal class CvCell : UICollectionViewCell
 		this.ContentView.AddGestureRecognizer(new UITapGestureRecognizer(() => InvokeTap()));
 	}
 
-	public WeakReference<Action<CvCell>> TapHandler { get; set; }
+	private TapHandlerCallback TapHandler;
+
+	public void SetTapHandlerCallback(Action<CvCell> callback)
+	{
+		TapHandler = new TapHandlerCallback(callback);
+	}
 
 	WeakReference<UIKeyCommand[]> keyCommands;
 
@@ -57,8 +62,7 @@ internal class CvCell : UICollectionViewCell
 	{
 		if (PositionInfo.Kind == PositionKind.Item)
 		{
-			if (TapHandler?.TryGetTarget(out var handler) ?? false)
-				handler?.Invoke(this);
+			TapHandler.Invoke(this);
 		}
 	}
 
@@ -142,4 +146,17 @@ internal class CvCell : UICollectionViewCell
                 viewPositionInfo.Update(positionInfo);
         }
     }
+	
+	class TapHandlerCallback
+	{
+		public TapHandlerCallback(Action<CvCell> callback)
+		{
+			Callback = callback;
+		}
+		
+		public readonly Action<CvCell> Callback;
+
+		public void Invoke(CvCell cell)
+			=> Callback?.Invoke(cell);
+	}
 }

--- a/VirtualListView/Apple/CvDataSource.ios.maccatalyst.cs
+++ b/VirtualListView/Apple/CvDataSource.ios.maccatalyst.cs
@@ -39,8 +39,8 @@ internal class CvDataSource : UICollectionViewDataSource
 			_ => "UNKNOWN",
 		};
 
-		var cell = collectionView.DequeueReusableCell(nativeReuseId, indexPath) as CvCell;
-		cell.TapHandler = new WeakReference<Action<CvCell>>(TapCellHandler);
+		var cell = (collectionView.DequeueReusableCell(nativeReuseId, indexPath) as CvCell)!;
+		cell.SetTapHandlerCallback(TapCellHandler);
 		cell.Handler = Handler;
 		cell.IndexPath = new WeakReference<NSIndexPath>(indexPath);
 


### PR DESCRIPTION
Using the WeakReference here was not correct, but to avoid the warning from the analyzer (not sure it would actually be a leak) refactored into a handler class.