### PR TITLE
Hide Global/Header Footer when adapter is empty

### DIFF
--- a/Sample/VirtualListViewSample/MusicLibraryPage.xaml
+++ b/Sample/VirtualListViewSample/MusicLibraryPage.xaml
@@ -72,6 +72,15 @@
 				<Label Padding="20" Text="That's all folks!" TextColor="White" HorizontalOptions="Center" />
 			</Grid>
 		</vlv:VirtualListView.GlobalFooter>
+		
+		<vlv:VirtualListView.EmptyView>
+			<Grid>
+				<Label
+					VerticalOptions="Center"
+					HorizontalOptions="Center"
+					Text="No Items" />
+			</Grid>
+		</vlv:VirtualListView.EmptyView>
 	</vlv:VirtualListView>
 
 </ContentPage>

--- a/VirtualListView/Adapters/VirtualListViewAdapterBase.cs
+++ b/VirtualListView/Adapters/VirtualListViewAdapterBase.cs
@@ -2,7 +2,12 @@
 
 public abstract class VirtualListViewAdapterBase<TSection, TItem> : IVirtualListViewAdapter
 {
-	public virtual int GetNumberOfSections() => 1;
+	// This adapter assumes we only ever have 1 section
+	// however we really want to return 0 if there's no items at all
+	// So, ask the derived class how many items might be in the first
+	// section and if any, we return 1 section otherwise 0
+	public virtual int GetNumberOfSections() =>
+		GetNumberOfItemsInSection(0) > 0 ? 1 : 0;
 
 	public event EventHandler OnDataInvalidated;
 

--- a/VirtualListView/PositionalViewSelector.cs
+++ b/VirtualListView/PositionalViewSelector.cs
@@ -28,12 +28,32 @@ internal class PositionalViewSelector
 	{
 		var sum = 0;
 
-		if (HasGlobalHeader)
-			sum += 1;
+		var hasAtLeastOneItem = false;
+		var numberOfSections = Adapter.GetNumberOfSections();
+
+		if (HasGlobalHeader && numberOfSections > 0)
+		{
+			// Make sure that there's at least one section with at least
+			// one item, otherwise it's 'empty'
+			// The default adapter may always return 1 for number of sections
+			// so it's not enough to check that
+			for (int s = 0; s < numberOfSections; s++)
+			{
+				if (Adapter.GetNumberOfItemsInSection(s) > 0)
+				{
+					sum += 1;
+					// If we found one, we can stop looping
+					// since we just care to calculate a spot
+					// for the header cell if the adapter isn't empty
+					hasAtLeastOneItem = true;
+					break;
+				}
+			}
+		}
 
 		if (Adapter != null)
 		{
-			for (int s = 0; s < Adapter.GetNumberOfSections(); s++)
+			for (int s = 0; s < numberOfSections; s++)
 			{
 				if (ViewSelector.SectionHasHeader(s))
 					sum += 1;
@@ -45,7 +65,9 @@ internal class PositionalViewSelector
 			}
 		}
 
-		if (HasGlobalFooter)
+		// Only count footer if there is already at least one item
+		// otherwise the adapter is empty and we shouldn't count it
+		if (HasGlobalFooter && hasAtLeastOneItem)
 			sum += 1;
 
 		return sum;


### PR DESCRIPTION
As described in #31 when the adapter is empty, the global header/footer (which are displayed in cells) overlap the empty view.

While the desired behaviour in some cases might be to make the emptyview fill the remaining space that the global header/footer do not occupy, the problem is the header/footer are implemented as cells in the list (so they scroll with the content of the list - if you didn't want them to scroll, you'd put them outside of the list anyway), so it would be challenging to make the empty view a cell which fills the remaining space.

This change instead hides the global header/footer if the adapter is empty, so that the empty view fills the entire space.  If you really want the same global header/footer to appear when the adapter is empty, you can simply add them also to your empty view template (eg: use a grid with `RowDefinitions="Auto,*Auto"` where your header and footer are rows 0 and 2 and the middle view fills the remaining space.