### PR TITLE
Fix iOS ignoring IsRefreshEnabled

### DIFF
--- a/Sample/VirtualListViewSample/SectionedAdapterPage.xaml
+++ b/Sample/VirtualListViewSample/SectionedAdapterPage.xaml
@@ -10,6 +10,8 @@
 		<vlv:VirtualListView
 			Grid.Row="0"
 			Grid.Column="0" Grid.ColumnSpan="3"
+			IsRefreshEnabled="False"
+			OnRefresh="Vlv_OnOnRefresh"
 			x:Name="vlv"
 			OnSelectedItemsChanged="vlv_SelectedItemsChanged"
 			SelectionMode="Single">

--- a/Sample/VirtualListViewSample/SectionedAdapterPage.xaml.cs
+++ b/Sample/VirtualListViewSample/SectionedAdapterPage.xaml.cs
@@ -47,4 +47,10 @@ public partial class SectionedAdapterPage : ContentPage
 		}
 	
 	}
+
+	private async void Vlv_OnOnRefresh(object sender, RefreshEventArgs e)
+	{
+		await Task.Delay(3000);
+		e.Complete();
+	}
 }

--- a/VirtualListView/Apple/VirtualListViewHandler.ios.maccatalyst.cs
+++ b/VirtualListView/Apple/VirtualListViewHandler.ios.maccatalyst.cs
@@ -36,13 +36,21 @@ public partial class VirtualListViewHandler : ViewHandler<IVirtualListView, UICo
 
 
 		refreshControl = new UIRefreshControl();
+		refreshControl.Enabled = VirtualView?.IsRefreshEnabled ?? false;
 		refreshControl.AddTarget(new EventHandler((s, a) =>
 		{
 			refreshControl.BeginRefreshing();
-			VirtualView?.Refresh(() => refreshControl.EndRefreshing());
+			try
+			{
+				VirtualView?.Refresh(() => refreshControl.EndRefreshing());
+			}
+			catch
+			{
+				refreshControl.EndRefreshing();
+			}
 		}), UIControlEvent.ValueChanged);
 
-		collectionView.AddSubview(refreshControl);
+		//collectionView.AddSubview(refreshControl);
 
 		collectionView.AlwaysBounceVertical = true;
 
@@ -176,8 +184,20 @@ public partial class VirtualListViewHandler : ViewHandler<IVirtualListView, UICo
 
 	public static void MapIsRefreshEnabled(VirtualListViewHandler handler, IVirtualListView virtualListView)
 	{
+		var isRefreshEnabled = virtualListView?.IsRefreshEnabled ?? false;
 		if (handler.refreshControl is not null)
-			handler.refreshControl.Enabled = virtualListView.IsRefreshEnabled;
+		{
+			if (isRefreshEnabled)
+			{
+				handler.PlatformView.AddSubview(handler.refreshControl);
+				handler.refreshControl.Enabled = true;
+			}
+			else
+			{
+				handler.refreshControl.Enabled = false;
+				handler.refreshControl.RemoveFromSuperview();
+			}
+		}
 	}
 
 


### PR DESCRIPTION
It turns out just setting .Enabled on UIRefreshControl doesn't do anything.  The fix is to control if the refresh control is added or not as a subview of the UICollectionView.

Fixes #28