### PR TITLE
Add InvalidateItems to the Adapter

### DIFF
--- a/Sample/VirtualListViewSample/Section.cs
+++ b/Sample/VirtualListViewSample/Section.cs
@@ -1,6 +1,20 @@
 ﻿namespace VirtualListViewSample;
 
-public class Section : List<string>
+public class Section : List<Item>
 {
 	public string Title { get; set; }
+}
+
+
+public class Item : BindableObject
+{
+
+    public static readonly BindableProperty NameProperty =
+        BindableProperty.Create(nameof(Name), typeof(string), typeof(Item), string.Empty);
+
+    public string Name
+    {
+        get => (string)GetValue(NameProperty);
+        set => SetValue(NameProperty, value);
+    }
 }

--- a/Sample/VirtualListViewSample/SectionedAdapter.cs
+++ b/Sample/VirtualListViewSample/SectionedAdapter.cs
@@ -2,7 +2,7 @@
 
 namespace VirtualListViewSample;
 
-public class SectionedAdapter : VirtualListViewAdapterBase<Section, string>
+public class SectionedAdapter : VirtualListViewAdapterBase<Section, Item>
 {
 	public SectionedAdapter(IList<Section> items) : base()
 	{
@@ -20,7 +20,7 @@ public class SectionedAdapter : VirtualListViewAdapterBase<Section, string>
 	public override int GetNumberOfItemsInSection(int sectionIndex)
 		=> Items[sectionIndex].Count;
 
-	public override string GetItem(int sectionIndex, int itemIndex)
+	public override Item GetItem(int sectionIndex, int itemIndex)
 		=> Items[sectionIndex][itemIndex];
 
 	public void AddItem(string sectionTitle, string itemName)
@@ -33,7 +33,7 @@ public class SectionedAdapter : VirtualListViewAdapterBase<Section, string>
 			Items.Add(section);
 		}
 
-		section.Add(itemName);
+		section.Add(new Item { Name = itemName });
 		InvalidateData();
 	}
 
@@ -51,4 +51,16 @@ public class SectionedAdapter : VirtualListViewAdapterBase<Section, string>
 
 		InvalidateData();
 	}
+
+	public void UpdateItem(int sectionIndex, int itemIndex)
+	{
+        var section = Items.ElementAtOrDefault(sectionIndex);
+
+        if (section is null)
+            return;
+
+		section[itemIndex].Name = $"{section[itemIndex].Name} Updated";
+
+		InvalidateItems(new ItemPosition(sectionIndex, itemIndex));
+    }
 }

--- a/Sample/VirtualListViewSample/SectionedAdapterPage.xaml
+++ b/Sample/VirtualListViewSample/SectionedAdapterPage.xaml
@@ -29,14 +29,19 @@
 				</DataTemplate>
 			</vlv:VirtualListView.SectionHeaderTemplate>
 			<vlv:VirtualListView.ItemTemplate>
-				<DataTemplate>
-					<Border
-					Margin="10,0,0,0"
-					Padding="4"
-					Background="LightBlue"
-					StrokeShape="{RoundRectangle CornerRadius=10}">
-						<Label Margin="10,6,10,6" Text="{Binding .}" />
-					</Border>
+				<DataTemplate x:DataType="local:Item">
+					<vlv:VirtualViewCell x:Name="cell">
+						<Border
+						Margin="10,0,0,0"
+						Padding="4"
+						Background="LightBlue"
+						StrokeShape="{RoundRectangle CornerRadius=10}">
+							<VerticalStackLayout>
+								<Button Text="Test" Clicked="ButtonAddTextClicked"  CommandParameter="{DynamicResource ItemPosition}" />
+								<Label Margin="10,6,10,6" Text="{Binding Name}" />
+							</VerticalStackLayout>
+						</Border>
+					</vlv:VirtualViewCell>
 				</DataTemplate>
 			</vlv:VirtualListView.ItemTemplate>
 		</vlv:VirtualListView>

--- a/Sample/VirtualListViewSample/SectionedAdapterPage.xaml.cs
+++ b/Sample/VirtualListViewSample/SectionedAdapterPage.xaml.cs
@@ -1,3 +1,4 @@
+using CommunityToolkit.Mvvm.Input;
 using System.Collections.ObjectModel;
 
 namespace VirtualListViewSample;
@@ -53,4 +54,15 @@ public partial class SectionedAdapterPage : ContentPage
 		await Task.Delay(3000);
 		e.Complete();
 	}
+
+    private void ButtonAddTextClicked(object sender, EventArgs e)
+    {
+		if (sender is Button button)
+		{
+			if (button.CommandParameter is ItemPosition itemPosition)
+			{
+                this.Adapter.UpdateItem(itemPosition.SectionIndex, itemPosition.ItemIndex);
+            }
+		}
+    }
 }

--- a/VirtualListView/Adapters/IVirtualListViewAdapter.cs
+++ b/VirtualListView/Adapters/IVirtualListViewAdapter.cs
@@ -13,4 +13,8 @@ public interface IVirtualListViewAdapter
 	event EventHandler OnDataInvalidated;
 
 	void InvalidateData();
+
+	event EventHandler<InvalidateItemsEventArgs> OnItemsInvalidated;
+
+	void InvalidateItems(params ItemPosition[] items);
 }

--- a/VirtualListView/Adapters/InvalidateItemsEventArgs.cs
+++ b/VirtualListView/Adapters/InvalidateItemsEventArgs.cs
@@ -1,0 +1,11 @@
+﻿namespace Microsoft.Maui.Adapters;
+
+public class InvalidateItemsEventArgs : EventArgs
+{
+	public InvalidateItemsEventArgs(params ItemPosition[] items)
+	{
+		Items = items;
+	}
+
+	public ItemPosition[] Items { get; }
+}

--- a/VirtualListView/Adapters/VirtualListViewAdapterBase.cs
+++ b/VirtualListView/Adapters/VirtualListViewAdapterBase.cs
@@ -11,6 +11,8 @@ public abstract class VirtualListViewAdapterBase<TSection, TItem> : IVirtualList
 
 	public event EventHandler OnDataInvalidated;
 
+	public event EventHandler<InvalidateItemsEventArgs> OnItemsInvalidated;
+
 	public virtual void InvalidateData()
 	{
 		OnDataInvalidated?.Invoke(this, EventArgs.Empty);
@@ -31,4 +33,12 @@ public abstract class VirtualListViewAdapterBase<TSection, TItem> : IVirtualList
 
 	void IVirtualListViewAdapter.InvalidateData()
 		=> InvalidateData();
+
+	public virtual void InvalidateItems(params ItemPosition[] items)
+	{
+		OnItemsInvalidated?.Invoke(this, new InvalidateItemsEventArgs(items));
+	}
+
+	void IVirtualListViewAdapter.InvalidateItems(params Microsoft.Maui.ItemPosition[] items)
+		=> InvalidateItems(items);
 }

--- a/VirtualListView/Apple/VirtualListViewHandler.ios.maccatalyst.cs
+++ b/VirtualListView/Apple/VirtualListViewHandler.ios.maccatalyst.cs
@@ -245,4 +245,24 @@ public partial class VirtualListViewHandler : ViewHandler<IVirtualListView, UICo
 		});
 		
 	}
+
+	void InvalidateItems(params ItemPosition[] items)
+	{
+		if (items is not null && items.Length > 0)
+		{
+			var paths = new List<NSIndexPath>();
+			foreach (var item in items)
+			{
+				paths.Add(NSIndexPath.FromItemSection(item.ItemIndex, item.SectionIndex));
+			}
+
+			if (paths.Count > 0)
+			{
+				this.PlatformView.InvokeOnMainThread(() =>
+				{
+					PlatformView.ReloadItems(paths.ToArray());
+				});
+			}
+		}
+	}
 }

--- a/VirtualListView/Controls/VirtualViewCell.cs
+++ b/VirtualListView/Controls/VirtualViewCell.cs
@@ -61,6 +61,7 @@ public class VirtualViewCell : ContentView, IPositionInfo
 		{
 			sectionIndex = value;
 			this.Resources[nameof(SectionIndex)] = sectionIndex;
+			this.Resources[nameof(ItemPosition)] = new  ItemPosition(sectionIndex, ItemIndex);
 			this.OnPropertyChanged(nameof(SectionIndex));
 		}
 	}
@@ -73,6 +74,7 @@ public class VirtualViewCell : ContentView, IPositionInfo
 		{
 			itemIndex = value;
 			this.Resources[nameof(ItemIndex)] = itemIndex;
+			this.Resources[nameof(ItemPosition)] = new ItemPosition(SectionIndex, itemIndex);
 			this.OnPropertyChanged(nameof(ItemIndex));
 			this.OnPropertyChanged(nameof(IsFirstItemInSection));
 			this.OnPropertyChanged(nameof(IsNotFirstItemInSection));

--- a/VirtualListView/Platforms/Android/VirtualListViewHandler.android.cs
+++ b/VirtualListView/Platforms/Android/VirtualListViewHandler.android.cs
@@ -164,4 +164,17 @@ public partial class VirtualListViewHandler : ViewHandler<IVirtualListView, Fram
 			UpdateEmptyViewVisibility();
 		}
 	}
+
+	void InvalidateItems(params ItemPosition[] items)
+	{
+		if (items is not null && items.Length > 0)
+		{
+			foreach (var item in items)
+			{
+				var rawPosition = PositionalViewSelector.GetPosition(item.SectionIndex, item.ItemIndex);
+
+				adapter.NotifyItemChanged(rawPosition);
+			}
+		}
+	}
 }

--- a/VirtualListView/Platforms/Windows/IrSource.cs
+++ b/VirtualListView/Platforms/Windows/IrSource.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Reflection;
 
 namespace Microsoft.Maui;
 
@@ -24,6 +25,12 @@ class IrSource : IReadOnlyList<IrDataWrapper>, INotifyCollectionChanged
 	public void Reset()
 	{
 		CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+	}
+
+	public void ResetItems(params ItemPosition[] items)
+	{
+		// TODO: Fire a more specific event
+		Reset();
 	}
 
 	public int Count

--- a/VirtualListView/Platforms/Windows/VirtualListViewHandler.windows.cs
+++ b/VirtualListView/Platforms/Windows/VirtualListViewHandler.windows.cs
@@ -164,4 +164,10 @@ public partial class VirtualListViewHandler : ViewHandler<IVirtualListView, WGri
 
 		UpdateEmptyViewVisibility();
 	}
+
+	void InvalidateItems(params ItemPosition[] items)
+	{
+		if (items is not null && items.Length > 0)
+			irSource?.ResetItems(items);
+	}
 }

--- a/VirtualListView/VirtualListViewHandler.cs
+++ b/VirtualListView/VirtualListViewHandler.cs
@@ -22,7 +22,7 @@ public partial class VirtualListViewHandler
 
 	public static CommandMapper<IVirtualListView, VirtualListViewHandler> CommandMapper = new(ViewCommandMapper)
 	{
-		[nameof(IVirtualListView.ScrollToItem)] = MapScrollToItem,
+		[nameof(IVirtualListView.ScrollToItem)] = MapScrollToItem
 	};
 
 	public static void MapScrollToItem(VirtualListViewHandler handler, IVirtualListView view, object parameter)
@@ -67,10 +67,16 @@ public partial class VirtualListViewHandler
 	public static void MapAdapter(VirtualListViewHandler handler, IVirtualListView virtualListView)
 	{
 		if (handler.currentAdapter != null)
+		{
 			handler.currentAdapter.OnDataInvalidated -= handler.Adapter_OnDataInvalidated;
+			handler.currentAdapter.OnItemsInvalidated -= handler.Adapter_OnItemsInvalidated;
+		}
 
 		if (virtualListView?.Adapter != null)
+		{
 			virtualListView.Adapter.OnDataInvalidated += handler.Adapter_OnDataInvalidated;
+			virtualListView.Adapter.OnItemsInvalidated += handler.Adapter_OnItemsInvalidated;
+		}
 
 		handler.currentAdapter = virtualListView.Adapter;
 		handler?.InvalidateData();
@@ -81,6 +87,11 @@ public partial class VirtualListViewHandler
 	void Adapter_OnDataInvalidated(object sender, EventArgs e)
 	{
 		InvalidateData();
+	}
+
+	void Adapter_OnItemsInvalidated(object sender, InvalidateItemsEventArgs e)
+	{
+		InvalidateItems(e.Items);
 	}
 
 	public bool IsItemSelected(int sectionIndex, int itemIndex)


### PR DESCRIPTION
This will help with 'resetting' an item if you change a property such that you expect it to change the size of the cell.

Workaround for iOS making life difficult here: https://github.com/Redth/Maui.VirtualListView/issues/29#issuecomment-2067749400

But also probably convenient in other situations too.