### PR TITLE
Implement FindVisiblePositions()

### DIFF
--- a/VirtualListView/Apple/VirtualListViewHandler.ios.maccatalyst.cs
+++ b/VirtualListView/Apple/VirtualListViewHandler.ios.maccatalyst.cs
@@ -255,4 +255,17 @@ public partial class VirtualListViewHandler : ViewHandler<IVirtualListView, UICo
 		});
 		
 	}
+	
+	public IReadOnlyList<IPositionInfo> FindVisiblePositions()
+	{
+		var positions = new List<PositionInfo>();
+			
+		foreach (var cell in PlatformView.VisibleCells)
+		{
+			if (cell is CvCell cvCell)
+				positions.Add(cvCell.PositionInfo);
+		}
+
+		return positions;
+	}
 }

--- a/VirtualListView/Controls/VirtualListView.cs
+++ b/VirtualListView/Controls/VirtualListView.cs
@@ -402,4 +402,12 @@ public partial class VirtualListView : View, IVirtualListView, IVirtualListViewS
 	void RaiseSelectedItemsChanged(ItemPosition[] previousSelection, ItemPosition[] newSelection)
 		=> this.OnSelectedItemsChanged?.Invoke(this, new SelectedItemsChangedEventArgs(previousSelection, newSelection));
 
+	public IReadOnlyList<IPositionInfo> FindVisiblePositions()
+	{
+#if ANDROID || IOS || MACCATALYST || WINDOWS
+		if (Handler is IVirtualListViewHandler handler)
+			return handler.FindVisiblePositions();
+#endif
+		return [];
+	}
 }

--- a/VirtualListView/IVirtualListView.cs
+++ b/VirtualListView/IVirtualListView.cs
@@ -49,6 +49,8 @@ public interface IVirtualListView : IView
 	void ClearSelectedItems();
 
 	void ScrollToItem(ItemPosition path, bool animated);
+
+	IReadOnlyList<IPositionInfo> FindVisiblePositions();
 }
 
 public enum ListOrientation

--- a/VirtualListView/IVirtualListViewHandler.cs
+++ b/VirtualListView/IVirtualListViewHandler.cs
@@ -1,0 +1,8 @@
+﻿namespace Microsoft.Maui;
+
+public interface IVirtualListViewHandler
+{
+#if ANDROID || IOS || MACCATALYST || WINDOWS
+	IReadOnlyList<IPositionInfo> FindVisiblePositions();
+#endif
+}

--- a/VirtualListView/Platforms/Android/VirtualListViewHandler.android.cs
+++ b/VirtualListView/Platforms/Android/VirtualListViewHandler.android.cs
@@ -195,4 +195,19 @@ public partial class VirtualListViewHandler : ViewHandler<IVirtualListView, Fram
 
 		recyclerView.HorizontalScrollBarEnabled = newHorizontalScrollVisiblility == ScrollBarVisibility.Always;
 	}
+	
+	public IReadOnlyList<IPositionInfo> FindVisiblePositions()
+	{
+		var positions = new List<IPositionInfo>();
+		
+		var firstVisibleItemPosition = layoutManager.FindFirstVisibleItemPosition();
+		var lastVisibleItemPosition = layoutManager.FindLastVisibleItemPosition();
+
+		for (var p = firstVisibleItemPosition; p <= lastVisibleItemPosition; p++)
+		{
+			positions.Add(PositionalViewSelector.GetInfo(p));
+		}
+
+		return positions;
+	}
 }

--- a/VirtualListView/VirtualListViewHandler.cs
+++ b/VirtualListView/VirtualListViewHandler.cs
@@ -2,7 +2,7 @@ using Microsoft.Maui.Adapters;
 
 namespace Microsoft.Maui;
 
-public partial class VirtualListViewHandler
+public partial class VirtualListViewHandler : IVirtualListViewHandler
 {
 	#if ANDROID || IOS || MACCATALYST || WINDOWS
 	public static new IPropertyMapper<IVirtualListView, VirtualListViewHandler> ViewMapper = new PropertyMapper<IVirtualListView, VirtualListViewHandler>(Handlers.ViewHandler.ViewMapper)


### PR DESCRIPTION
This fixes #41 

Now the virtual list view has a method `IReadOnlyList<IPositionInfo> FindVisiblePositions()` which will return all of the position info for every item visible on the control.

You can use this to find the first visible item index or see if there's a header visible, etc.  Sky is the limit.